### PR TITLE
Support custom page events

### DIFF
--- a/lib/analyse.js
+++ b/lib/analyse.js
@@ -49,7 +49,8 @@ const indexers = {
 
 function customEvent (msg) {
   return (line) => {
-    return line.message.message.method === 'Tracing.dataCollected' && line.message.message.params.name === 'TimeStamp' && line.message.message.params.args.data.message === msg;
+    const message = line.message.message;
+    return message.method === 'Tracing.dataCollected' && message.params.name === 'TimeStamp' && message.params.args.data.message === msg;
   };
 }
 

--- a/lib/analyse.js
+++ b/lib/analyse.js
@@ -23,6 +23,10 @@ const metrics = {
     fn: (line) => {
       return line.message.message.method === 'Page.loadEventFired';
     }
+  },
+  'Ads Rendered': {
+    indexer: 'first',
+    fn: customEvent('google-ad-rendered')
   }
 };
 
@@ -42,6 +46,12 @@ const indexers = {
       }, 0);
   }
 };
+
+function customEvent (msg) {
+  return (line) => {
+    return line.message.message.method === 'Tracing.dataCollected' && line.message.message.params.name === 'TimeStamp' && line.message.message.params.args.data.message === msg;
+  };
+}
 
 function analyse (data) {
   return data.map((logs) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,13 @@ function analyser (opts) {
   opts.sleep = opts.sleep || 5000;
   opts.scroll = opts.scroll !== undefined ? opts.scroll : true;
   opts.inject = (session) => {
-    return session.execute(`googletag=googletag||{};googletag.cmd=googletag.cmd||[];googletag.cmd.push(()=>googletag.pubads().addEventListener('slotRenderEnded', (event) => { console.timeStamp('google-ad-rendered'); }))`);
+    return session.execute(`
+      window.googletag=window.googletag||{};
+      window.googletag.cmd=window.googletag.cmd||[];
+      window.googletag.cmd.push(()=>googletag.pubads().addEventListener('slotRenderEnded', (event) => {
+        console.timeStamp('google-ad-rendered');
+      }));
+    `);
   };
 
   return runner(opts)

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,9 +10,9 @@ function analyser (opts) {
   }
   opts.count = opts.count || 1;
   opts.sleep = opts.sleep || 5000;
-
-  opts.inject = function (session) {
-    return session.execute('function f () { window.scrollBy(0,5); window.requestAnimationFrame(f); } window.requestAnimationFrame(f);');
+  opts.scroll = opts.scroll !== undefined ? opts.scroll : true;
+  opts.inject = (session) => {
+    return session.execute(`googletag=googletag||{};googletag.cmd=googletag.cmd||[];googletag.cmd.push(()=>googletag.pubads().addEventListener('slotRenderEnded', (event) => { console.timeStamp('google-ad-rendered'); }))`);
   };
 
   return runner(opts)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "babar": "0.0.3",
     "lodash.meanby": "^4.10.0",
     "minimist": "^1.2.0",
-    "timeliner": "^0.4.0"
+    "timeliner": "^0.5.1"
   },
   "devDependencies": {
     "semistandard": "^9.1.0"


### PR DESCRIPTION
Makes a call to `console.timeStamp` on google ads rendered events, which allows for the timestamps to be collected in the performance logs.