### PR TITLE
Display results to console in table

### DIFF
--- a/lib/analyse.js
+++ b/lib/analyse.js
@@ -1,34 +1,4 @@
-const metrics = {
-  'M1': {
-    description: 'Time to First Paint',
-    indexer: 'first',
-    fn: (line) => {
-      return line.message.message.method === 'Tracing.dataCollected' && line.message.message.params.name === 'Paint';
-    }
-  },
-  'M2': {
-    description: 'DomContentLoaded',
-    indexer: 'first',
-    fn: (line) => {
-      return line.message.message.method === 'Page.domContentEventFired';
-    }
-  },
-  /*'M3': {
-    description: 'Render Settlement',
-    indexer: 'last',
-    fn: (line) => {
-      const paint = line.message.message.method === 'Tracing.dataCollected' && line.message.message.params.name === 'Layout';
-      return paint;// && line.message.message.params.args.data.clip[1] < 800;
-    }
-  },*/
-  'M6': {
-    description: 'Page Load',
-    indexer: 'first',
-    fn: (line) => {
-      return line.message.message.method === 'Page.loadEventFired';
-    }
-  }
-};
+const metrics = require('./metrics');
 
 const indexers = {
   first: (data, test) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const runner = require('timeliner');
 const analyse = require('./analyse');
 const chart = require('./fps-chart');
 const reporters = require('./reporters');
+const metrics = require('./metrics');
 
 function analyser (opts) {
   if (!opts.url) {
@@ -45,7 +46,7 @@ function analyser (opts) {
       });
       return report;
     })
-    .then((report) => Promise.all(enabledReporters.map((r) => reporters[r].call(this, report))));
+    .then((report) => Promise.all(enabledReporters.map((r) => reporters[r].call(this, report, metrics))));
 }
 
 module.exports = analyser;

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,0 +1,25 @@
+const metrics = {
+  'M1': {
+    description: 'Time to First Paint',
+    indexer: 'first',
+    fn: (line) => {
+      return line.message.message.method === 'Tracing.dataCollected' && line.message.message.params.name === 'Paint';
+    }
+  },
+  'M2': {
+    description: 'DomContentLoaded',
+    indexer: 'first',
+    fn: (line) => {
+      return line.message.message.method === 'Page.domContentEventFired';
+    }
+  },
+  'M6': {
+    description: 'Page Load',
+    indexer: 'first',
+    fn: (line) => {
+      return line.message.message.method === 'Page.loadEventFired';
+    }
+  }
+};
+
+module.exports = metrics;

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -1,6 +1,11 @@
-module.exports = function(report) {
+var Table = require('cli-table');
+
+module.exports = function (report, metrics) {
+  const table = new Table({ head: ['Metric', 'Description', 'Mean Time (s)'] });
+
   console.log(`Based on ${report.summary.count} load(s) of ${report.summary.url}:`);
   report.metrics.forEach((metric) => {
-    console.log(`${metric.key}: ${(metric.value/1000).toFixed(2)}s`);
+    table.push([metric.key, metrics[metric.key].description, `${(metric.value/1000).toFixed(2)}`]);
   });
+  console.log(table.toString());
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "babar": "0.0.3",
     "bluebird": "^3.4.6",
+    "cli-table": "^0.3.1",
     "lodash.meanby": "^4.10.0",
     "minimist": "^1.2.0",
     "timeliner": "^0.4.0"


### PR DESCRIPTION
This makes the console output a lot easier to read and understand.

Splits metrics out into their own module so the configuration can be re-used.